### PR TITLE
Increase php memory_limit

### DIFF
--- a/site/config/application.php
+++ b/site/config/application.php
@@ -94,6 +94,12 @@ Config::define('DISALLOW_FILE_EDIT', true);
 Config::define('DISALLOW_FILE_MODS', true);
 
 /**
+ * Pressbooks Settings
+ */
+define('WP_MEMORY_LIMIT', env('WP_MEMORY_LIMIT') ?: '96M'); // Everywhere
+define('WP_MAX_MEMORY_LIMIT', env('WP_MAX_MEMORY_LIMIT') ?: '256M'); // In the admin
+
+/**
  * Debugging Settings
  */
 Config::define('WP_DEBUG_DISPLAY', false);

--- a/trellis/group_vars/all/main.yml
+++ b/trellis/group_vars/all/main.yml
@@ -22,3 +22,5 @@ raw_vars:
   - vault_users.*.salt
   - vault_wordpress_env_defaults
   - vault_wordpress_sites
+
+php_memory_limit: 256M

--- a/trellis/group_vars/production/wordpress_sites.yml
+++ b/trellis/group_vars/production/wordpress_sites.yml
@@ -27,3 +27,6 @@ wordpress_sites:
       provider: letsencrypt
     cache:
       enabled: true
+    env:
+      wp_memory_limit: 96M
+      wp_max_memory_limit: "{{ php_memory_limit }}"


### PR DESCRIPTION
The error.log had a few instances of
"Allowed memory size of .* bytes exhausted"
Server should have sufficient memory to accommodate limit increase.